### PR TITLE
eds-extension: don't overwrite calendar name with account name

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-address-book-service (0.1.3+ubports1) UNRELEASED; urgency=medium
+address-book-service (0.1.3+ubports1) xenial; urgency=medium
 
   * No change rebuild to generate sources in ubports repo
 

--- a/eds-extension/module-ubuntu-sources.c
+++ b/eds-extension/module-ubuntu-sources.c
@@ -97,13 +97,19 @@ ubuntu_sources_config_source (EUbuntuSources *extension,
                               AgAccount *ag_account)
 {
     ESourceExtension *source_extension;
+    const gchar *account_name, *source_name;
+
     g_debug("CONFIGURE SOURCE: %s,%s", e_source_get_display_name(source),
             e_source_get_uid(source));
 
-    g_object_bind_property (
-        ag_account, "display-name",
-        source, "display-name",
-        G_BINDING_SYNC_CREATE);
+    account_name = ag_account_get_display_name (ag_account);
+    source_name = e_source_get_display_name (source);
+    if (g_strcmp0 (account_name, source_name) == 0) {
+        g_object_bind_property (
+            ag_account, "display-name",
+            source, "display-name",
+            G_BINDING_DEFAULT);
+    }
 
     g_object_bind_property (
         ag_account, "enabled",


### PR DESCRIPTION
Binding the account name to the source name causes the calendar names to
be overwritten with the account name.  Keeping the source name updated
makes sense only for the primary calendar associated with an account,
which indeed is named after the account.  In Ubports, the account name
never changes, so the binding is actually unnecessary; we still keep the
binding, out of completeness.

Fixes: https://github.com/ubports/ubuntu-touch/issues/762